### PR TITLE
Let an array with a single entry be an array in JSON

### DIFF
--- a/code/random_domain.ps1
+++ b/code/random_domain.ps1
@@ -46,10 +46,10 @@ for ( $i = 1; $i -le $UserCount; $i++ ){
     $last_name = (Get-Random -InputObject $last_names)
     $password = (Get-Random -InputObject $passwords)
 
-    $new_user = @{ `
+    $new_user = @{
         "name"="$first_name $last_name"
         "password"="$password"
-        "groups" = (Get-Random -InputObject $groups).name
+        "groups" = @((Get-Random -InputObject $groups).name)
         }
 
     if ( $local_admin_indexes | Where { $_ -eq $i  } ){
@@ -64,7 +64,7 @@ for ( $i = 1; $i -le $UserCount; $i++ ){
     $passwords.Remove($password)
 }
 
-ConvertTo-Json -InputObject @{ 
+ConvertTo-Json -Depth 100 -InputObject @{
     "domain"= "xyz.com"
     "groups"=$groups
     "users"=$users


### PR DESCRIPTION
If the the "groups" property of the "user" object has only one entry, and we want to convert our list of users to JSON, then PowerShell doesn't create an array with a single entry as the value for the "group" property, but instead a scalar – a simple string.

The Problem is that PowerShell uses a default traversal depth of 2, if we use `ConverTo-Json`.
We fix our issues by using a greater traversal depth with the Argument `-Depth:100`.

https://stackoverflow.com/questions/53583677/unexpected-convertto-json-results-answer-it-has-a-default-depth-of-2